### PR TITLE
Addressing the `.mongooseTypeOptions/.mongoose is not a function`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ typings/
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+.idea

--- a/README.md
+++ b/README.md
@@ -280,13 +280,30 @@ const schemaOptions = zodSchema._def[MongooseSchemaOptionsSymbol];
 
 ### I get the error: `.mongooseTypeOptions/.mongoose is not a function`
 
+It is due to that `mongoose-zod` extends the prototype of `z` to chain the functions you are experiencing trouble with.
 This error indicates that zod extensions this package adds have not been registered yet. This may happen when you've used either of these methods but haven't imported anything from `mongoose-zod`. In this case the best strategy would probably be to **import the package** at the entrypoint of your application like that:
-
 ```ts
 import 'mongoose-zod';
 ...
 ```
 
+When this is not possible in your use case, or you prefer a function over an prototype extend you can use the following
+
+```ts
+import {addMongooseTypeOptions, toZodMongooseSchema} from './extensions';
+
+const zodSchema = toZodMongooseSchema(z.object({
+  nickname: addMongooseTypeOptions(z.string().min(1), {unique: true}),
+  friends: z.number().int().min(1).array().optional(),
+}))
+```
+instead of 
+```ts
+const zodSchema = z.object({
+  nickname: z.string().min(1).mongooseTypeOptions({unique: true}),
+  friends: z.number().int().min(1).array().optional(),
+}).mongoose();
+```
 
 ### Be careful when using shared schemas with `.mongooseTypeOptions/.mongoose`
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,16 @@ import 'mongoose-zod';
 ...
 ```
 
-When this is not possible in your use case, or you prefer a function over an prototype extend you can use the following
+You can also use the `z` that is included in `mongoose-zod` instead of the `z` from `zod` directly to be sure you have the correct `z` reference
+```ts
+import {z} from 'mongoose-zod';
+
+...
+const userZodSchema = z.object({ ... }).mongoose();
+const UserSchema = toMongooseSchema(userZodSchema);
+```
+
+When this is not possible in your use case, or you prefer a function over a prototype extend you can use the following
 
 ```ts
 import {addMongooseTypeOptions, toZodMongooseSchema} from './extensions';

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bracketSpacing": false,
     "endOfLine": "lf"
   },
-  "devDependencies": {
+  "dependencies": {
     "@tsconfig/node14": "^1.0.3",
     "@types/jest": "^29.4.0",
     "@types/lodash": "^4.14.186",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:unit:watch": "jest --watch",
     "test": "npm run lint && npm run test:unit",
     "build": "rimraf dist && tsup src/index.ts --dts --treeshake --format esm,cjs --target=node14",
-    "prepublishOnly": "npm run test && npm run build"
+    "prepublishOnly": "npm run test && npm run build",
+    "postinstall": "npm run build"
   },
   "homepage": "https://github.com/andreww2012/mongoose-zod",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test:unit:watch": "jest --watch",
     "test": "npm run lint && npm run test:unit",
     "build": "rimraf dist && tsup src/index.ts --dts --treeshake --format esm,cjs --target=node14",
-    "prepublishOnly": "npm run test && npm run build",
-    "postinstall": "npm run build"
+    "prepublishOnly": "npm run test && npm run build"
   },
   "homepage": "https://github.com/andreww2012/mongoose-zod",
   "repository": {
@@ -47,7 +46,7 @@
     "bracketSpacing": false,
     "endOfLine": "lf"
   },
-  "dependencies": {
+  "devDependencies": {
     "@tsconfig/node14": "^1.0.3",
     "@types/jest": "^29.4.0",
     "@types/lodash": "^4.14.186",

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,5 +1,5 @@
 import type {SchemaOptions, SchemaTypeOptions} from 'mongoose';
-import {z} from 'zod';
+import {ZodObject, z} from 'zod';
 import type {PartialLaconic} from './utils.js';
 
 export const MongooseTypeOptionsSymbol = Symbol.for('MongooseTypeOptions');
@@ -22,7 +22,7 @@ export interface MongooseMetadata<
   >;
 }
 
-interface ZodMongooseDef<
+export interface ZodMongooseDef<
   ZodType extends z.ZodTypeAny,
   DocType,
   TInstanceMethods extends {} = {},
@@ -116,12 +116,25 @@ declare module 'zod' {
   }
 }
 
+export const toZodMongooseSchema = function (zObject: ZodObject<any>, metadata = {}) {
+  return ZodMongoose.create({mongoose: metadata, innerType: zObject});
+};
 if (!z.ZodObject.prototype.mongoose) {
   z.ZodObject.prototype.mongoose = function (metadata = {}) {
     return ZodMongoose.create({mongoose: metadata, innerType: this});
   };
 }
 
+export const addMongooseTypeOptions = function (
+  zObject: z.ZodType,
+  options: SchemaTypeOptions<any, any> | undefined,
+) {
+  zObject._def[MongooseTypeOptionsSymbol] = {
+    ...zObject._def[MongooseTypeOptionsSymbol],
+    ...options,
+  };
+  return zObject;
+};
 if (!z.ZodType.prototype.mongooseTypeOptions) {
   z.ZodType.prototype.mongooseTypeOptions = function (options) {
     this._def[MongooseTypeOptionsSymbol] = {
@@ -176,3 +189,5 @@ declare module 'mongoose' {
       | [MZRequiredFn<ThisType | null>, string];
   }
 }
+
+export {z} from 'zod';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ export {bufferMongooseGetter, genTimestampsSchema} from './mongoose-helpers.js';
 export {toMongooseSchema} from './to-mongoose.js';
 export type {UnknownKeysHandling} from './to-mongoose.js';
 export {mongooseZodCustomType} from './zod-helpers.js';
-export {MongooseSchemaOptionsSymbol, MongooseTypeOptionsSymbol} from './extensions.js';
+export {MongooseSchemaOptionsSymbol, MongooseTypeOptionsSymbol, ZodMongoose} from './extensions.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,11 @@ export {bufferMongooseGetter, genTimestampsSchema} from './mongoose-helpers.js';
 export {toMongooseSchema} from './to-mongoose.js';
 export type {UnknownKeysHandling} from './to-mongoose.js';
 export {mongooseZodCustomType} from './zod-helpers.js';
-export {MongooseSchemaOptionsSymbol, MongooseTypeOptionsSymbol, ZodMongoose} from './extensions.js';
+export {
+  MongooseSchemaOptionsSymbol,
+  MongooseTypeOptionsSymbol,
+  ZodMongoose,
+  toZodMongooseSchema,
+  addMongooseTypeOptions,
+  z,
+} from './extensions.js';


### PR DESCRIPTION
The error is caused because the `z.ZObject` prototype is extended

Because is some cases there can be multiple imports of `z` it is impossible to tell if the right prototype is extended. It is a bad practice because you have no control over the `z` object as an user of this library.

That is why:
* We created a wrapper for the extension function to pass down your own z object
* We expose the specific extended z object

We created some tests and updated the docs accordingly.

[x] `npm run test`
[x] `npm run lint`
[x] linked issue #2 

Kind regards