### PR TITLE
Fix Webpack import.meta error

### DIFF
--- a/src/to-mongoose.ts
+++ b/src/to-mongoose.ts
@@ -28,9 +28,9 @@ const originalMongooseLean = M.Query.prototype.lean;
 
 registerCustomMongooseZodTypes();
 
-const mlvPlugin = tryImportModule('mongoose-lean-virtuals', import.meta);
-const mldPlugin = tryImportModule('mongoose-lean-defaults', import.meta);
-const mlgPlugin = tryImportModule('mongoose-lean-getters', import.meta);
+const mlvPlugin = tryImportModule('mongoose-lean-virtuals', import.meta.url);
+const mldPlugin = tryImportModule('mongoose-lean-defaults', import.meta.url);
+const mlgPlugin = tryImportModule('mongoose-lean-getters', import.meta.url);
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 const getFixedOptionFn = (fn: Function) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,8 +10,8 @@ export const getValidEnumValues = (obj: any) => {
   return Object.values(filtered);
 };
 
-export const tryImportModule = (id: string, importMeta: ImportMeta): {module: any} | null => {
-  const require = createRequire(new URL(importMeta.url));
+export const tryImportModule = (id: string, importMetaUrl: string): {module: any} | null => {
+  const require = createRequire(new URL(importMetaUrl));
   try {
     const modulePath = require.resolve(id);
     // eslint-disable-next-line import/no-dynamic-require

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -3,4 +3,4 @@ import {tryImportModule} from '../src/utils.js';
 
 export const getSchemaPlugins = (schema: M.Schema) =>
   (schema as any).plugins.map(({fn}: any) => fn);
-export const importModule = (id: string) => tryImportModule(id, import.meta)?.module;
+export const importModule = (id: string) => tryImportModule(id, import.meta.url)?.module;


### PR DESCRIPTION
This PR:
- Fixes this error I kept getting with Webpack by changing the function to use just the `import.meta.url` rather than `import.meta`

```
Critical dependency: Accessing import.meta directly is unsupported (only property access is supported)
```

